### PR TITLE
Allow port 80 for certificate renewal

### DIFF
--- a/tasks/firewalld.yml
+++ b/tasks/firewalld.yml
@@ -13,7 +13,7 @@
     - port: "{{ coturn_min_port }}-{{ coturn_max_port }}"
       proto: udp
 
-- name: firewalld enable coturn tls ports
+- name: firewalld enable coturn tls port and certificate renewal
   firewalld:
     port: item
     permanent: yes
@@ -21,4 +21,5 @@
   loop:
     - "{{ coturn_tls_listening_port }}/tcp"
     - "{{ coturn_tls_listening_port }}/udp"
+    - "80/tcp"
   when: coturn_use_tls

--- a/tasks/ufw.yml
+++ b/tasks/ufw.yml
@@ -23,7 +23,7 @@
     - port: "{{ coturn_min_port }}:{{ coturn_max_port }}"
       proto: udp
 
-- name: ufw allow coturn tls port
+- name: ufw allow coturn tls port and certificate renewal
   ufw:
     rule: allow
     port: "{{ item.port }}"
@@ -33,6 +33,8 @@
       proto: tcp
     - port: "{{ coturn_tls_listening_port }}"
       proto: udp
+    - port: 80
+      proto: tcp
   when: coturn_use_tls
 
 - name: enable firewall


### PR DESCRIPTION
Let's Encrypt requires port 80 to be open for certificate renewal. This commit adds port 80 to the firewall rules for coturn when using TLS.